### PR TITLE
Margin attribution palcement next ot figure instead of under

### DIFF
--- a/src/sphinx_metadata_figure/__init__.py
+++ b/src/sphinx_metadata_figure/__init__.py
@@ -326,7 +326,11 @@ class MetadataFigure(Figure):
                             figure_node.append(n)
                         else:
                             figure_nodes.append(n)
+                elif placement == 'margin':
+                    # Insert margin admonition before the figure so it appears next to it
+                    figure_nodes = display_nodes + figure_nodes
                 else:
+                    # For 'admonition' placement, append after the figure
                     figure_nodes.extend(display_nodes)
 
         return figure_nodes


### PR DESCRIPTION
When using `placement='margin'`, the attribution admonition now appears **before** the figure instead of after it, allowing it to render correctly in the margin alongside the figure.

Previously, the margin admonition would appear below the figure, defeating the purpose of the margin placement option.