### PR TITLE
Update default config for figure placement and license

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -11,7 +11,18 @@ This section is useful for user type 3-5.
 
 ## Examples using default settings
 
-These examples assume that the config only has the default options.
+These examples assume that the config only has the default options except for the `placement`, `summaries`, and `individual` options which are set as follows:
+
+```yaml
+sphinx:
+  config:
+    metadata_figure_settings:
+      style: 
+        placement: caption
+      license:
+        summaries: true
+        individual: true
+```
 
 ### Example 1: Complete Metadata
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ sphinx:
   config:
     metadata_figure_settings:
       style: 
-        placement: caption
+        placement: hide
         show: author,license,date,copyright,source
         admonition_title: Attribution
         admonition_class: attribution
       license:
         link_license: true
         strict_check: false
-        summaries: true
+        summaries: false
         individual: false
         substitute_missing: false
         default_license: CC-BY

--- a/src/sphinx_metadata_figure/__init__.py
+++ b/src/sphinx_metadata_figure/__init__.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Global defaults for figure attribution (can be overridden per file or per directive)
 METADATA_FIGURE_DEFAULTS_STYLE = {
-    'placement': 'caption',  # caption | admonition | margin | hide
+    'placement': 'hide',  # caption | admonition | margin | hide
     'show': 'author,license,date,copyright,source',     # which fields to display
     'admonition_title': 'Attribution',            # title for the admonition block
     'admonition_class': 'attribution', # extra CSS class on the admonition
@@ -42,7 +42,7 @@ METADATA_FIGURE_DEFAULTS_STYLE = {
 METADATA_FIGURE_DEFAULTS_LICENSE = {
     'link_license'       : True,
     'strict_check'       : False,
-    'summaries'          : True,
+    'summaries'          : False,
     'individual'         : False,
     'substitute_missing' : False,
     'default_license'    : 'CC-BY'


### PR DESCRIPTION
So that inclusion of extension doesn't immediately lead to warnings. As this is also used by sphinx-prime-applets, proper metadata of prime applets is added, but otherwise it would also introduce warnings of all figures and add captions to all of them.