### PR TITLE
Improve date handling and license check in figure metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ The figure directive is extended with the following options to add metadata:
 - `license`:
   - Specify the license type of the image. Must be one of the valid license types.
 - `date`:
-  - Optionally specify the creation date of the image in `YYYY-MM-DD` format.
+  - Optionally specify the creation date of the image.
+  - This value can be:
+    - a date in `YYYY-MM-DD` format
+    - `today`, which will result in using the date at which the build is performed.
 - `copyright`:
   - Optionally specify a text with copyright information for the image.
 - `source`:

--- a/src/sphinx_metadata_figure/__init__.py
+++ b/src/sphinx_metadata_figure/__init__.py
@@ -197,11 +197,10 @@ class MetadataFigure(Figure):
         if not date_value:
              date_settings = settings['date']
              if date_settings['substitute_missing']:
-                default_date = date_settings['default_date']
-                if default_date == 'today':
-                    date_value = datetime.today().strftime('%Y-%m-%d')
-                else:
-                    date_value = default_date
+                date_value = date_settings['default_date']
+        if date_value:
+            if date_value == 'today':
+                date_value = datetime.today().strftime('%Y-%m-%d')
         if date_value:
             try:
                 datetime.strptime(date_value, '%Y-%m-%d')
@@ -576,6 +575,9 @@ def add_unnumbered_caption(app, doctree, fromdocname):
     """Add captions to unnumbered figures for metadata display."""
     for node in doctree.traverse(nodes.figure):
         has_caption = False
+        has_license_html = 'license_html' in node
+        if not has_license_html:
+            continue
         for child in node.children:
             if isinstance(child, nodes.caption):
                 has_caption = True


### PR DESCRIPTION
Updated the README to clarify accepted date formats and the use of 'today' for image creation dates. Refactored date substitution logic in MetadataFigure to consistently handle 'today' and default values. Enhanced add_unnumbered_caption to skip figures without license metadata.

closes #23 
closes #24 