### PR TITLE
Ensure myst_nb extension loads before setup

### DIFF
--- a/src/sphinx_metadata_figure/__init__.py
+++ b/src/sphinx_metadata_figure/__init__.py
@@ -519,6 +519,9 @@ def setup(app):
     Returns:
         dict: Extension metadata
     """
+    # Ensure MysST NB is loaded before this extension so the glue domain is registered
+    app.setup_extension('myst_nb')
+
     # Register configuration values    
     app.add_config_value('metadata_figure_settings', {}, 'env')
 


### PR DESCRIPTION
Added a call to app.setup_extension('myst_nb') in the setup function to guarantee that the MysST NB extension is loaded first, ensuring the glue domain is registered before this extension.

Closes #30 